### PR TITLE
Update action versions  and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  # Enable version updates for npm
+- package-ecosystem: "maven"  
+  directory: "/"  
+  schedule:
+    interval: "weekly"
+    

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,20 +6,24 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v6
       with:
         java-version: 17
     - name: Maven Build
       run: mvn -B package -Pcode-coverage
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: code-coverage-report
         path: target/site/jacoco/**


### PR DESCRIPTION
I realized that the actions were all using old versions and 

- have updated them to the current latest versions. 
- add concurrency rule so that only one workflow runs for each branch
- add dependabot so that dependencies are automatically upgraded (merge must still be done manually by maintainer)